### PR TITLE
koyeb deploy updated to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The fastest way to deploy the alist to koyeb is to click the **Deploy to Koyeb** button below.
 
-[![deploy to koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&image=xhofe/alist:v3.28.0&ports=5244;http;/&name=alist&env[PORT]=5244&env[DB_TYPE]=mysql&env[DB_HOST]=host&env[DB_PORT]=3306&env[DB_USER]=alist&env[DB_PASS]=password&env[DB_NAME]=alist&env[DB_TABLE_PREFIX]=alist_&env[DB_SSL_MODE]=false&env[CDN]=https://cdn.jsdelivr.net/npm/alist-web@3.28.0/dist)
+[![deploy to koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&image=xhofe/alist:latest&ports=5244;http;/&name=alist&env[PORT]=5244&env[DB_TYPE]=mysql&env[DB_HOST]=host&env[DB_PORT]=3306&env[DB_USER]=alist&env[DB_PASS]=password&env[DB_NAME]=alist&env[DB_TABLE_PREFIX]=alist_&env[DB_SSL_MODE]=false&env[CDN]=https://cdn.jsdelivr.net/npm/alist-web@$version/dist)
 
 Update the environment variables as follows:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The fastest way to deploy the alist to koyeb is to click the **Deploy to Koyeb** button below.
 
-[![deploy to koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&image=xhofe/alist:v3.28.0&ports=5244;http;/&name=alist&env[PORT]=5244&env[DB_TYPE]=mysql&env[DB_HOST]=host&env[DB_PORT]=3306&env[DB_USER]=alist&env[DB_PASS]password=&env[DB_NAME]=alist&env[DB_TABLE_PREFIX]=alist_&env[DB_SSL_MODE]=false&env[CDN]=https://cdn.jsdelivr.net/npm/alist-web@3.28.0/dist)
+[![deploy to koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&image=xhofe/alist:v3.28.0&ports=5244;http;/&name=alist&env[PORT]=5244&env[DB_TYPE]=mysql&env[DB_HOST]=host&env[DB_PORT]=3306&env[DB_USER]=alist&env[DB_PASS]=password&env[DB_NAME]=alist&env[DB_TABLE_PREFIX]=alist_&env[DB_SSL_MODE]=false&env[CDN]=https://cdn.jsdelivr.net/npm/alist-web@3.28.0/dist)
 
 Update the environment variables as follows:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,31 @@
 
 The fastest way to deploy the alist to koyeb is to click the **Deploy to Koyeb** button below.
 
-[![deploy to koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&image=xhofe/alist:v2.6.4&ports=8080;http;/&name=alist&env[DB_TYPE]=sqlite3&env[DB_HOST]=host&[DB_PORT]=3306&env[DB_USER]=alist&env[DB_PASS]password=&[DB_NAME]=alist&env[DB_TABLE_PREFIX]=alist_&env[CACHE_EXPIRATION]=60&env[CLEANUP_INTERVAL]=120&env[ASSETS]=https://npm.elemecdn.com/alist-web@$version/dist)
+[![deploy to koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&image=xhofe/alist:v3.28.0&ports=5244;http;/&name=alist&env[PORT]=5244&env[DB_TYPE]=mysql&env[DB_HOST]=host&env[DB_PORT]=3306&env[DB_USER]=alist&env[DB_PASS]password=&env[DB_NAME]=alist&env[DB_TABLE_PREFIX]=alist_&env[DB_SSL_MODE]=false&env[CDN]=https://cdn.jsdelivr.net/npm/alist-web@3.28.0/dist)
+
+Update the environment variables as follows:
+
+`DB_TYPE:` mysql (you can also use sqlite3 and postgres. mysql is for remote db)
+
+`DB_HOST:` provide db host address here (keep blank for sqlite3 db)
+
+`DB_USER:` provide db username here (keep blank for sqlite3 db)
+
+`DB_PASS:` provide db password here (keep blank for sqlite3 db)
+
+`DB_TABLE_PREFIX:` alist_ (keep as it is)
+
+`CDN:` https://cdn.jsdelivr.net/npm/alist-web@3.28.0/dist (you can also use other CDN. but this CDN is tested and working.)
+
+`DB_PORT:` 3306 (keep as it is)
+
+`PORT:` 5244 (keep as it is)
+
+`DB_NAME:` provide db name here (keep blank for sqlite3 db)
+
+`DB_SSL_MODE:` false (only if you use mysql or postgres db. for sqlite3 this env variable is not needed)
+
+N.B: During deploying keep watching the deploy logs to get the admin password. It will be appeared as initial password: <password> text. For remote db you can't change it later using `./alist admin` command.
 
 ### database
 You may need to use another remote MySQL database as instance restarts will lose data.


### PR DESCRIPTION
* Doc updated to deploy alist v3 to koyeb
* Fixed an issue where DB_PORT and DB_NAME doesn't appear on koyeb environment list after clicking the link
* Changed ASSETS variable to CDN as per v3 change
* Updated CDN url to a working one for koyeb to fix the blank white page issue after deploying
* Updated readme to provide useful information for remote db deployment